### PR TITLE
Setup scan sensors to optionally allow triggers

### DIFF
--- a/Runtime/Sensors/ArcScanSensor.cs
+++ b/Runtime/Sensors/ArcScanSensor.cs
@@ -37,7 +37,7 @@ namespace Konfus.Systems.Sensor_Toolkit
                 nextDir += origin;
 
                 // hit something, stop!
-                if (Physics.Linecast(prevDir, nextDir, out RaycastHit hit, DetectionFilter, QueryTriggerInteraction.Ignore))
+                if (Physics.Linecast(prevDir, nextDir, out RaycastHit hit, DetectionFilter, interactTriggers ? QueryTriggerInteraction.Collide : QueryTriggerInteraction.Ignore))
                 {
                     var hitsDetected = new Hit[1];
                     hitsDetected[0] = new Hit() { point = hit.point, normal = hit.normal, gameObject = hit.collider.gameObject };

--- a/Runtime/Sensors/BoxScanSensor.cs
+++ b/Runtime/Sensors/BoxScanSensor.cs
@@ -36,7 +36,7 @@ namespace Konfus.Systems.Sensor_Toolkit
                             transform.rotation,
                             SensorLength,
                             DetectionFilter,
-                            QueryTriggerInteraction.Ignore))
+                            interactTriggers ? QueryTriggerInteraction.Collide : QueryTriggerInteraction.Ignore))
                     {
                         var hitsDetected = new Hit[1];
                         hitsDetected[0] = new Hit()
@@ -57,7 +57,7 @@ namespace Konfus.Systems.Sensor_Toolkit
                         transform.rotation,
                         SensorLength,
                         DetectionFilter,
-                        QueryTriggerInteraction.Ignore);
+                        interactTriggers ? QueryTriggerInteraction.Collide : QueryTriggerInteraction.Ignore);
 
                     // sort hits by distance
                     if (hitsArray.Length > 0)
@@ -88,7 +88,7 @@ namespace Konfus.Systems.Sensor_Toolkit
                             sensorSize/2,
                             transform.rotation,
                             DetectionFilter,
-                            QueryTriggerInteraction.Ignore))
+                            interactTriggers ? QueryTriggerInteraction.Collide : QueryTriggerInteraction.Ignore))
                     {
                         isTriggered = true;
                         return true;

--- a/Runtime/Sensors/LineScanSensor.cs
+++ b/Runtime/Sensors/LineScanSensor.cs
@@ -9,7 +9,7 @@ namespace Konfus.Systems.Sensor_Toolkit
             isTriggered = false;
 
             if (Physics.Linecast(transform.position, transform.position + transform.forward * SensorLength, out RaycastHit hit,
-                    DetectionFilter, QueryTriggerInteraction.Ignore))
+                    DetectionFilter, interactTriggers ? QueryTriggerInteraction.Collide : QueryTriggerInteraction.Ignore))
             {
                 var hitsDetected = new Hit[1];
                 hitsDetected[0] = new Hit() { point = hit.point, normal = hit.normal, gameObject = hit.collider.gameObject };

--- a/Runtime/Sensors/ScanSensor.cs
+++ b/Runtime/Sensors/ScanSensor.cs
@@ -7,6 +7,9 @@ namespace Konfus.Systems.Sensor_Toolkit
         [SerializeField]
         private float sensorLength = 1f;
 
+        [SerializeField]
+        protected bool interactTriggers = false;
+
         public float SensorLength => sensorLength;
         
         public abstract bool Scan();

--- a/Runtime/Sensors/SphereScanSensor.cs
+++ b/Runtime/Sensors/SphereScanSensor.cs
@@ -27,7 +27,8 @@ namespace Konfus.Systems.Sensor_Toolkit
             if (sensorType == Type.Standard && SensorLength != 0)
             {
                 var ray = new Ray(transform.position + Vector3.forward * sensorRadius / 2, transform.forward);
-                if (Physics.SphereCast(ray, sensorRadius, out RaycastHit hit, SensorLength, DetectionFilter, QueryTriggerInteraction.Ignore))
+                if (Physics.SphereCast(ray, sensorRadius, out RaycastHit hit, SensorLength, DetectionFilter,
+                        interactTriggers ? QueryTriggerInteraction.Collide : QueryTriggerInteraction.Ignore))
                 {
                     var hitsDetected = new Hit[1];
                     hitsDetected[0] = new Hit() { point = hit.point, normal = hit.normal, gameObject = hit.collider.gameObject };
@@ -43,7 +44,8 @@ namespace Konfus.Systems.Sensor_Toolkit
                     sensorRadius, 
                     transform.forward, 
                     SensorLength,
-                    DetectionFilter, QueryTriggerInteraction.Ignore);
+                    DetectionFilter,
+                    interactTriggers ? QueryTriggerInteraction.Collide : QueryTriggerInteraction.Ignore);
                 if (hitsArray.Length > 0)
                 {
                     Array.Sort(hitsArray, (s1, s2) =>


### PR DESCRIPTION
For when users can interact but also drive over an interactable object. Useful for non-static interactable objects that we won't want blocking players or cpu, like permanent boosts that can be swapped out for one another.